### PR TITLE
年齢別集計で、10色以上の場合に、色が反映されない不具合を修正。

### DIFF
--- a/Service/SalesReportService.php
+++ b/Service/SalesReportService.php
@@ -524,9 +524,6 @@ class SalesReportService
             ++$raw[$age]['time'];
             $backgroundColor[$orderNumber] = $this->getColor($orderNumber);
             ++$orderNumber;
-            if ($orderNumber > 10) {
-                $orderNumber = $orderNumber % 10;
-            }
         }
         // Sort by age ASC.
         ksort($result);


### PR DESCRIPTION
compatible problem https://github.com/eccubevn/sales-report-plugin/commit/025b9674fd957d1e17a8adba9b0dacbfeda830ce